### PR TITLE
fix(ssl): set sni when providing a server-name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,4 +42,6 @@
 
 ### unreleased
 
+- fix: set sni when using ssl verify
+
 - forked from https://github.com/thibaultcha/lua-resty-socket

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,6 @@
 
 ### unreleased
 
-- fix: set sni when using ssl verify
+- fix: set sni when a server-name is provided
 
 - forked from https://github.com/thibaultcha/lua-resty-socket

--- a/lib/resty/luasocket/init.lua
+++ b/lib/resty/luasocket/init.lua
@@ -115,7 +115,7 @@ do
       self.sock:close()
       return 1
     end,
-    sslhandshake = function(self, reused_session, _, verify, send_status_req, opts)
+    sslhandshake = function(self, reused_session, server_name, verify, send_status_req, opts)
       if opts == nil and type(send_status_req) == "table" then
         -- backward compat after OR added send_status_req, shift args
         opts, send_status_req = send_status_req, nil       -- luacheck: ignore
@@ -137,6 +137,10 @@ do
       local sock, err = ssl.wrap(self.sock, params)
       if not sock then
         return return_bool and false or nil, err
+      end
+
+      if verify then
+        sock:sni(server_name)
       end
 
       local ok, err = sock:dohandshake()

--- a/lib/resty/luasocket/init.lua
+++ b/lib/resty/luasocket/init.lua
@@ -139,7 +139,7 @@ do
         return return_bool and false or nil, err
       end
 
-      if verify then
+      if server_name then
         sock:sni(server_name)
       end
 


### PR DESCRIPTION
It seems that without SNI settings the server certificate verification will fail.

A simple reproduce example:

```
local http = require "resty.luasocket.http"
local resty_luasocket = require "resty.luasocket"
local inspect = require "inspect"

resty_luasocket.force_luasocket("timer", true)

print(ngx.get_phase())

local client = http.new()

local res, err = client:request_uri("https://www.google.com/", {
        method = "GET",
        ssl_verify = true,
})

print(res)
print(err)


(kong-dev) ubuntu@ip-172-31-93-219:~/kong-ee$ resty g.lua
timer
2023/04/20 06:30:28 [warn] 1368916#0: *2 [lua] _G write guard:12: writing a global Lua variable ('socket') which may lead to race conditions between concurrent requests, so prefer the use of 'local' variables
stack traceback:
        [C]: at 0x7f93889653e0
        [C]: in function 'require'
        ...ong-ee/bazel-bin/build/kong-dev/share/lua/5.1/socket.lua:12: in main chunk
        [C]: in function 'require'
        ...in/build/kong-dev/share/lua/5.1/resty/luasocket/init.lua:237: in function 'ngx_socket_tcp'
        ...ee/bazel-bin/build/kong-dev/share/lua/5.1/resty/http.lua:133: in function 'new'
        g.lua:9: in function 'file_gen'
        init_worker_by_lua:45: in function <init_worker_by_lua:43>
        [C]: in function 'xpcall'
        init_worker_by_lua:52: in function <init_worker_by_lua:50>, context: ngx.timer

certificate verify failed
```

KAG-656