### PR TITLE
fix(luasocket): workaround for blocking read-0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 
 ### Version x.x.x, unreleased
 
+- fix: implemented workaround for luasocket [issue #427](https://github.com/lunarmodules/luasocket/issues/427)
+  which caused blocking while not reading
+  [#6](https://github.com/Tieske/lua-resty-luasocket/pull/6)
 - chore: updated some documentation to clarify
   [#3](https://github.com/Tieske/lua-resty-luasocket/pull/3)
 

--- a/lib/resty/luasocket/init.lua
+++ b/lib/resty/luasocket/init.lua
@@ -90,6 +90,14 @@ do
 
       return self.sock:send(data)
     end,
+    receive = function(self, pattern)
+      if pattern == 0 then
+        -- LuaSocket will block until data is available even if no data is being read.
+        -- see: https://github.com/lunarmodules/luasocket/issues/427
+        return ""
+      end
+      return self.sock:receive(pattern)
+    end,
     getreusedtimes = function() return 0 end,
     settimeout = function(self, t)
       if t then


### PR DESCRIPTION
workaround for luasocket [issue #427](https://github.com/lunarmodules/luasocket/issues/427) which caused blocking while not reading.